### PR TITLE
TypeCast Default_units to fix type error

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import MainContent from './ui/MainContent';
 import {API_ID, DEFAULT_CITY, DEFAULT_UNITS, APP_ENVIRONMENT} from './lib/config';
 import { weatherResponseParser } from './lib/utils';
 import { weatherResponsePlaceholder } from './lib/placeholder';
+import { UnitSystemKey } from './lib/definitions';
 
 
 async function getCityWeather(){
@@ -33,7 +34,7 @@ export default async function Home() {
   
   const res = await getCityWeather();
 
-  const {sideData, mainData} = weatherResponseParser(res.data, DEFAULT_UNITS);
+  const {sideData, mainData} = weatherResponseParser(res.data, DEFAULT_UNITS as UnitSystemKey);
 
 
   return (


### PR DESCRIPTION
# This pull request will:
* Fix DEFAULT_UNITS Argument of type 'string' is not assignable to parameter of type 'UnitSystemKey' by type casting it.